### PR TITLE
DEVPROD-32806: Fix token expiry field corruption for Kanopy CLI compatibility

### DIFF
--- a/src/evergreen_mcp/oidc_auth.py
+++ b/src/evergreen_mcp/oidc_auth.py
@@ -254,8 +254,12 @@ class OIDCAuthManager:
                 token_data["expires_at"] = time.time() + token_data["expires_in"]
             # Add/update 'expiry' field in ISO 8601 format for Kanopy CLI compatibility
             # Kanopy CLI (Go) expects this field to exist and be in RFC3339/ISO8601 format
-            expiry_timestamp = token_data.get("expires_at", time.time() + token_data["expires_in"])
-            token_data["expiry"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(expiry_timestamp))
+            expiry_timestamp = token_data.get(
+                "expires_at", time.time() + token_data["expires_in"]
+            )
+            token_data["expiry"] = time.strftime(
+                "%Y-%m-%dT%H:%M:%SZ", time.gmtime(expiry_timestamp)
+            )
         return token_data
 
     def _read_token_file(self) -> Optional[dict]:

--- a/src/evergreen_mcp/oidc_auth.py
+++ b/src/evergreen_mcp/oidc_auth.py
@@ -241,11 +241,21 @@ class OIDCAuthManager:
         for token file persistence, allowing other tools that read the token file to
         check expiry without decoding the JWT.
 
-        Note: _check_token_expiry() decodes the JWT directly and doesn't use expires_at,
+        Also adds/updates the 'expiry' field in ISO 8601 format for compatibility
+        with Kanopy CLI (Go), which expects this field for token expiration checking.
+        Without this, Kanopy CLI may write the zero-value time (0001-01-01T00:00:00Z)
+        back to the token file, corrupting it for other consumers.
+
+        Note: _check_token_expiry() decodes the JWT directly and doesn't use these fields,
         but this normalization is kept for compatibility with external token consumers.
         """
-        if "expires_in" in token_data and "expires_at" not in token_data:
-            token_data["expires_at"] = time.time() + token_data["expires_in"]
+        if "expires_in" in token_data:
+            if "expires_at" not in token_data:
+                token_data["expires_at"] = time.time() + token_data["expires_in"]
+            # Add/update 'expiry' field in ISO 8601 format for Kanopy CLI compatibility
+            # Kanopy CLI (Go) expects this field to exist and be in RFC3339/ISO8601 format
+            expiry_timestamp = token_data.get("expires_at", time.time() + token_data["expires_in"])
+            token_data["expiry"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(expiry_timestamp))
         return token_data
 
     def _read_token_file(self) -> Optional[dict]:

--- a/src/evergreen_mcp/oidc_auth.py
+++ b/src/evergreen_mcp/oidc_auth.py
@@ -254,9 +254,7 @@ class OIDCAuthManager:
                 token_data["expires_at"] = time.time() + token_data["expires_in"]
             # Add/update 'expiry' field in ISO 8601 format for Kanopy CLI compatibility
             # Kanopy CLI (Go) expects this field to exist and be in RFC3339/ISO8601 format
-            expiry_timestamp = token_data.get(
-                "expires_at", time.time() + token_data["expires_in"]
-            )
+            expiry_timestamp = token_data.get("expires_at")
             token_data["expiry"] = time.strftime(
                 "%Y-%m-%dT%H:%M:%SZ", time.gmtime(expiry_timestamp)
             )

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -263,6 +263,84 @@ class TestTokenExpiry:
         assert remaining == 0
 
 
+class TestNormalizeTokenData:
+    """Test token data normalization."""
+
+    def test_normalize_adds_expires_at_and_expiry(self, auth_manager):
+        """Test that _normalize_token_data adds expires_at and expiry fields."""
+        token_data = {"access_token": "test", "expires_in": 599}
+
+        result = auth_manager._normalize_token_data(token_data)
+
+        # Should add expires_at (Unix timestamp)
+        assert "expires_at" in result
+        assert isinstance(result["expires_at"], (int, float))
+        assert result["expires_at"] > time.time()
+
+        # Should add expiry (ISO 8601 format for Kanopy CLI compatibility)
+        assert "expiry" in result
+        assert isinstance(result["expiry"], str)
+        # Verify ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
+        assert len(result["expiry"]) == 20
+        assert result["expiry"].endswith("Z")
+        assert "T" in result["expiry"]
+
+    def test_normalize_preserves_existing_expires_at(self, auth_manager):
+        """Test that existing expires_at is preserved when present."""
+        existing_expires_at = time.time() + 1000
+        token_data = {
+            "access_token": "test",
+            "expires_in": 599,
+            "expires_at": existing_expires_at,
+        }
+
+        result = auth_manager._normalize_token_data(token_data)
+
+        # Should preserve existing expires_at
+        assert result["expires_at"] == existing_expires_at
+        # Should still add/update expiry field based on expires_at
+        assert "expiry" in result
+
+    def test_normalize_updates_expiry_from_existing_expires_at(self, auth_manager):
+        """Test that expiry is calculated from existing expires_at if present."""
+        future_time = time.time() + 3600  # 1 hour from now
+        token_data = {
+            "access_token": "test",
+            "expires_in": 599,
+            "expires_at": future_time,
+        }
+
+        result = auth_manager._normalize_token_data(token_data)
+
+        # expiry should be based on the existing expires_at, not expires_in
+        expected_expiry = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(future_time))
+        assert result["expiry"] == expected_expiry
+
+    def test_normalize_no_expires_in_no_changes(self, auth_manager):
+        """Test that without expires_in, no normalization happens."""
+        token_data = {"access_token": "test"}
+
+        result = auth_manager._normalize_token_data(token_data.copy())
+
+        # Should not add expires_at or expiry without expires_in
+        assert "expires_at" not in result
+        assert "expiry" not in result
+
+    def test_normalize_overwrites_stale_expiry(self, auth_manager):
+        """Test that stale expiry field from Kanopy CLI is overwritten."""
+        token_data = {
+            "access_token": "test",
+            "expires_in": 599,
+            "expiry": "0001-01-01T00:00:00Z",  # Go zero-value time
+        }
+
+        result = auth_manager._normalize_token_data(token_data)
+
+        # Should overwrite the stale Go zero-value expiry
+        assert result["expiry"] != "0001-01-01T00:00:00Z"
+        assert result["expiry"].startswith("20")  # Should be current year (2025+)
+
+
 class TestUserIdExtraction:
     """Test user ID extraction from JWT tokens."""
 

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -13,6 +13,7 @@ These tests validate the OIDCAuthManager class including:
 import asyncio
 import base64
 import json
+import datetime
 import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, mock_open, patch
@@ -280,10 +281,12 @@ class TestNormalizeTokenData:
         # Should add expiry (ISO 8601 format for Kanopy CLI compatibility)
         assert "expiry" in result
         assert isinstance(result["expiry"], str)
-        # Verify ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ
-        assert len(result["expiry"]) == 20
-        assert result["expiry"].endswith("Z")
-        assert "T" in result["expiry"]
+        # Verify ISO 8601 format and that the time is within 1 minute of now + 599s
+        parsed = datetime.datetime.strptime(result["expiry"], "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=datetime.timezone.utc
+        )
+        expected = time.time() + 599
+        assert abs(parsed.timestamp() - expected) < 60
 
     def test_normalize_preserves_existing_expires_at(self, auth_manager):
         """Test that existing expires_at is preserved when present."""

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -12,8 +12,8 @@ These tests validate the OIDCAuthManager class including:
 
 import asyncio
 import base64
-import json
 import datetime
+import json
 import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, mock_open, patch

--- a/tests/test_oidc_auth.py
+++ b/tests/test_oidc_auth.py
@@ -282,9 +282,9 @@ class TestNormalizeTokenData:
         assert "expiry" in result
         assert isinstance(result["expiry"], str)
         # Verify ISO 8601 format and that the time is within 1 minute of now + 599s
-        parsed = datetime.datetime.strptime(result["expiry"], "%Y-%m-%dT%H:%M:%SZ").replace(
-            tzinfo=datetime.timezone.utc
-        )
+        parsed = datetime.datetime.strptime(
+            result["expiry"], "%Y-%m-%dT%H:%M:%SZ"
+        ).replace(tzinfo=datetime.timezone.utc)
         expected = time.time() + 599
         assert abs(parsed.timestamp() - expected) < 60
 


### PR DESCRIPTION
Disclaimer - this PR had minimal human intervention. The vast majority was via AI.
I believe it did a good job in summarizing in all cases but have made minimal edits for clarity. I've also noted I've locally used this branch and observed a parallel agent workflow that consistently failed functioning again.


< 🤖AI Slop🤖>
## Ticket

**Jira:** [DEVPROD-32806](https://jira.mongodb.org/browse/DEVPROD-32806)

### Summary
Fixes a token file corruption issue where the `expiry` field was being overwritten with Go's zero-value time (`0001-01-01T00:00:00Z`) when Kanopy CLI reads tokens written by this MCP server.

### Problem
The token file was getting corrupted because:
1. Kanopy CLI (Go) writes tokens with an `expiry` field in ISO 8601 format
2. OAuth servers return `expires_in` (seconds), not `expiry`
3. Our code only added `expires_at` (Unix timestamp) but not `expiry`
4. When Kanopy CLI read our token, the missing `expiry` became Go's zero time, which it then wrote back to the file

### Solution
Updated `_normalize_token_data()` in `oidc_auth.py` to also compute and add the `expiry` field in ISO 8601 format (`YYYY-MM-DDTHH:MM:SSZ`) that Kanopy CLI expects.

### Changes
- **src/evergreen_mcp/oidc_auth.py**: Added `expiry` field computation in ISO 8601 format
- **tests/test_oidc_auth.py**: Added comprehensive tests for token normalization logic

### Testing
- (human edited) Lower value unit tests around format
- Verified both `expires_at` (Unix timestamp) and `expiry` (ISO 8601) fields are now correctly populated
- (this is human) Moderate agentic workflows that used to fail from token expiry succeed using this branch
</🤖AI Slop🤖>
