### PR TITLE
DEVPROD-35197: Deploy to Kanopy: auto-prod on push to main, manual staging

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,45 +1,15 @@
 # Drone deploy pipelines for the devprod-evergreen Kanopy namespace.
 #
 # The container image is built and published by the GitHub Action
-# .github/workflows/docker-build.yml on every push to the `deploy` branch,
-# producing ghcr.io/evergreen-ci/evergreen-mcp-server:deploy (floating tag).
+# .github/workflows/docker-build.yml on every push to the `main` branch,
+# producing ghcr.io/evergreen-ci/evergreen-mcp-server:main (floating tag).
 # Drone only deploys — it does not build images.
 #
 # Triggers:
-#   * push to `deploy` → auto-deploy to staging
-#   * `drone build promote <build> production` → deploy to prod
+#   * push to `main` → auto-deploy to production
+#   * `drone build promote <build> staging` → deploy to staging
 #
-# All pipelines are gated on branch=deploy so other branches never deploy.
-
----
-kind: pipeline
-type: kubernetes
-name: publish-to-staging
-
-trigger:
-  branch:
-    - deploy
-  event:
-    - push
-
-steps:
-  - name: deploy
-    image: quay.io/mongodb/drone-helm:v3
-    settings:
-      mode: upgrade
-      chart: mongodb/web-app
-      chart_version: 4.34.3
-      release: evergreen-mcp-server
-      namespace: devprod-evergreen
-      api_server: https://api.staging.corp.mongodb.com
-      kubernetes_token:
-        from_secret: staging_kubernetes_token
-      add_repos:
-        - mongodb=https://10gen.github.io/helm-charts
-      values_files:
-        - environments/common.yml
-        - environments/staging.yml
-      wait_for_upgrade: true
+# All pipelines are gated on branch=main so other branches never deploy.
 
 ---
 kind: pipeline
@@ -48,11 +18,9 @@ name: publish-to-production
 
 trigger:
   branch:
-    - deploy
+    - main
   event:
-    - promote
-  target:
-    - production
+    - push
 
 steps:
   - name: deploy
@@ -71,4 +39,36 @@ steps:
       values_files:
         - environments/common.yml
         - environments/production.yml
+      wait_for_upgrade: true
+
+---
+kind: pipeline
+type: kubernetes
+name: publish-to-staging
+
+trigger:
+  branch:
+    - main
+  event:
+    - promote
+  target:
+    - staging
+
+steps:
+  - name: deploy
+    image: quay.io/mongodb/drone-helm:v3
+    settings:
+      mode: upgrade
+      chart: mongodb/web-app
+      chart_version: 4.34.3
+      release: evergreen-mcp-server
+      namespace: devprod-evergreen
+      api_server: https://api.staging.corp.mongodb.com
+      kubernetes_token:
+        from_secret: staging_kubernetes_token
+      add_repos:
+        - mongodb=https://10gen.github.io/helm-charts
+      values_files:
+        - environments/common.yml
+        - environments/staging.yml
       wait_for_upgrade: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,27 +1,15 @@
----
-kind: pipeline
-type: kubernetes
-name: build-and-publish
-
-trigger:
-  branch:
-    - deploy
-  event:
-    - push
-
-steps:
-  - name: build-and-publish
-    image: plugins/kaniko-ecr
-    settings:
-      registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
-      repo: devprod-evergreen/evergreen-mcp-server
-      region: us-east-1
-      tags:
-        - ${DRONE_COMMIT_SHA:0:7}
-      access_key:
-        from_secret: ecr_access_key
-      secret_key:
-        from_secret: ecr_secret_key
+# Drone deploy pipelines for the devprod-evergreen Kanopy namespace.
+#
+# The container image is built and published by the GitHub Action
+# .github/workflows/docker-build.yml on every push to the `deploy` branch,
+# producing ghcr.io/evergreen-ci/evergreen-mcp-server:deploy (floating tag).
+# Drone only deploys — it does not build images.
+#
+# Triggers:
+#   * push to `deploy` → auto-deploy to staging
+#   * `drone build promote <build> production` → deploy to prod
+#
+# All pipelines are gated on branch=deploy so other branches never deploy.
 
 ---
 kind: pipeline
@@ -32,12 +20,7 @@ trigger:
   branch:
     - deploy
   event:
-    - promote
-  target:
-    - staging
-
-depends_on:
-  - build-and-publish
+    - push
 
 steps:
   - name: deploy
@@ -56,7 +39,6 @@ steps:
       values_files:
         - environments/common.yml
         - environments/staging.yml
-      values: image.tag=${DRONE_COMMIT_SHA:0:7}
       wait_for_upgrade: true
 
 ---
@@ -71,9 +53,6 @@ trigger:
     - promote
   target:
     - production
-
-depends_on:
-  - build-and-publish
 
 steps:
   - name: deploy
@@ -92,5 +71,4 @@ steps:
       values_files:
         - environments/common.yml
         - environments/production.yml
-      values: image.tag=${DRONE_COMMIT_SHA:0:7}
       wait_for_upgrade: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,96 @@
+---
+kind: pipeline
+type: kubernetes
+name: build-and-publish
+
+trigger:
+  branch:
+    - deploy
+  event:
+    - push
+
+steps:
+  - name: build-and-publish
+    image: plugins/kaniko-ecr
+    settings:
+      registry: 795250896452.dkr.ecr.us-east-1.amazonaws.com
+      repo: devprod-evergreen/evergreen-mcp-server
+      region: us-east-1
+      tags:
+        - ${DRONE_COMMIT_SHA:0:7}
+      access_key:
+        from_secret: ecr_access_key
+      secret_key:
+        from_secret: ecr_secret_key
+
+---
+kind: pipeline
+type: kubernetes
+name: publish-to-staging
+
+trigger:
+  branch:
+    - deploy
+  event:
+    - promote
+  target:
+    - staging
+
+depends_on:
+  - build-and-publish
+
+steps:
+  - name: deploy
+    image: quay.io/mongodb/drone-helm:v3
+    settings:
+      mode: upgrade
+      chart: mongodb/web-app
+      chart_version: 4.34.3
+      release: evergreen-mcp-server
+      namespace: devprod-evergreen
+      api_server: https://api.staging.corp.mongodb.com
+      kubernetes_token:
+        from_secret: staging_kubernetes_token
+      add_repos:
+        - mongodb=https://10gen.github.io/helm-charts
+      values_files:
+        - environments/common.yml
+        - environments/staging.yml
+      values: image.tag=${DRONE_COMMIT_SHA:0:7}
+      wait_for_upgrade: true
+
+---
+kind: pipeline
+type: kubernetes
+name: publish-to-production
+
+trigger:
+  branch:
+    - deploy
+  event:
+    - promote
+  target:
+    - production
+
+depends_on:
+  - build-and-publish
+
+steps:
+  - name: deploy
+    image: quay.io/mongodb/drone-helm:v3
+    settings:
+      mode: upgrade
+      chart: mongodb/web-app
+      chart_version: 4.34.3
+      release: evergreen-mcp-server
+      namespace: devprod-evergreen
+      api_server: https://api.prod.corp.mongodb.com
+      kubernetes_token:
+        from_secret: prod_kubernetes_token
+      add_repos:
+        - mongodb=https://10gen.github.io/helm-charts
+      values_files:
+        - environments/common.yml
+        - environments/production.yml
+      values: image.tag=${DRONE_COMMIT_SHA:0:7}
+      wait_for_upgrade: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,6 +2,8 @@ name: Build and Push Docker Image
 
 on:
   push:
+    branches:
+      - deploy
     tags:
       - 'v*'
   # Manual trigger for testing
@@ -67,7 +69,7 @@ jobs:
         cache-to: type=gha,mode=max
 
     - name: Push Docker image
-      if: github.event_name != 'pull_request' && (github.event.inputs.push_image == 'true' || github.ref_type == 'tag')
+      if: github.event_name != 'pull_request' && (github.event.inputs.push_image == 'true' || github.ref_type == 'tag' || github.ref == 'refs/heads/deploy')
       uses: docker/build-push-action@v5
       with:
         context: .

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,7 +3,7 @@ name: Build and Push Docker Image
 on:
   push:
     branches:
-      - deploy
+      - main
     tags:
       - 'v*'
   # Manual trigger for testing
@@ -69,7 +69,7 @@ jobs:
         cache-to: type=gha,mode=max
 
     - name: Push Docker image
-      if: github.event_name != 'pull_request' && (github.event.inputs.push_image == 'true' || github.ref_type == 'tag' || github.ref == 'refs/heads/deploy')
+      if: github.event_name != 'pull_request' && (github.event.inputs.push_image == 'true' || github.ref_type == 'tag' || github.ref == 'refs/heads/main')
       uses: docker/build-push-action@v5
       with:
         context: .

--- a/environments/common.yml
+++ b/environments/common.yml
@@ -1,15 +1,20 @@
 # Shared values for evergreen-mcp-server in the devprod-evergreen namespace.
 # Layered with environments/staging.yml or environments/production.yml.
 # Chart: mongodb/web-app (https://10gen.github.io/helm-charts)
+#
+# Pattern modeled on evergreen-ci/lumber, which deploys the same chart in
+# the same namespace family. Single container, streamable-http transport.
+# If SSE is ever needed, deploy a second helm release with --transport sse
+# rather than complicating this chart with sidecarContainers.
 
 image:
-  # Image is built and published by .github/workflows/docker-build.yml on every
-  # push to the `deploy` branch. The `:deploy` tag always points at the latest
-  # commit on that branch.
+  # Image is built and published by .github/workflows/docker-build.yml on
+  # every push to the `deploy` branch. The `:deploy` tag always points at
+  # the latest commit on that branch.
   repository: ghcr.io/evergreen-ci/evergreen-mcp-server
   tag: deploy
 
-# Main container: streamable-http on :8080 (path /mcp)
+# CLI args for the main container — serve streamable-http on :8080.
 args:
   - "--transport"
   - "streamable-http"
@@ -18,47 +23,22 @@ args:
   - "--port"
   - "8080"
 
-# Sidecar: SSE transport on :8081 (path /sse)
-sidecars:
-  sse:
-    image: ghcr.io/evergreen-ci/evergreen-mcp-server:deploy
-    args:
-      - "--transport"
-      - "sse"
-      - "--host"
-      - "0.0.0.0"
-      - "--port"
-      - "8081"
-    ports:
-      - containerPort: 8081
-        name: sse
-    env:
-      - name: EVERGREEN_USER
-        valueFrom:
-          secretKeyRef:
-            name: evergreen-mcp-server-secrets
-            key: EVERGREEN_USER
-      - name: EVERGREEN_API_KEY
-        valueFrom:
-          secretKeyRef:
-            name: evergreen-mcp-server-secrets
-            key: EVERGREEN_API_KEY
-      - name: SENTRY_ENABLED
-        value: "true"
-
 services:
-  - name: streamable-http
-    port: 8080
+  - name: http
+    ingress: true
+    port: 80
     targetPort: 8080
-    ingress: true
-    probes: true
-  - name: sse
-    port: 8081
-    targetPort: 8081
-    ingress: true
+    protocol: TCP
+    type: ClusterIP
     probes: true
 
-# Secret `evergreen-mcp-server-secrets` is provisioned out-of-band per namespace:
+ingress:
+  enabled: true
+  path: /
+  # hosts list is set per-env in staging.yml / production.yml
+
+# Secret `evergreen-mcp-server-secrets` is provisioned out-of-band per
+# namespace:
 #   helm ksec set evergreen-mcp-server-secrets \
 #     EVERGREEN_USER=<user> EVERGREEN_API_KEY=<key> -n devprod-evergreen
 envSecrets:
@@ -70,10 +50,14 @@ env:
 
 mesh:
   enabled: true
+  permissive: true
+
+serviceAccount:
+  enabled: true
 
 ownership:
   # TODO: swap to a team-alias email once the service has a clear owner
   driEmail: shreeven.kommireddy@mongodb.com
 
 security:
-  dataClassification: internal
+  dataClassification: "Internal"

--- a/environments/common.yml
+++ b/environments/common.yml
@@ -3,8 +3,11 @@
 # Chart: mongodb/web-app (https://10gen.github.io/helm-charts)
 
 image:
-  repository: 795250896452.dkr.ecr.us-east-1.amazonaws.com/devprod-evergreen/evergreen-mcp-server
-  # tag is injected per-deploy via `--set image.tag=<sha>` in .drone.yml
+  # Image is built and published by .github/workflows/docker-build.yml on every
+  # push to the `deploy` branch. The `:deploy` tag always points at the latest
+  # commit on that branch.
+  repository: ghcr.io/evergreen-ci/evergreen-mcp-server
+  tag: deploy
 
 # Main container: streamable-http on :8080 (path /mcp)
 args:
@@ -18,7 +21,7 @@ args:
 # Sidecar: SSE transport on :8081 (path /sse)
 sidecars:
   sse:
-    image: 795250896452.dkr.ecr.us-east-1.amazonaws.com/devprod-evergreen/evergreen-mcp-server
+    image: ghcr.io/evergreen-ci/evergreen-mcp-server:deploy
     args:
       - "--transport"
       - "sse"

--- a/environments/common.yml
+++ b/environments/common.yml
@@ -9,10 +9,10 @@
 
 image:
   # Image is built and published by .github/workflows/docker-build.yml on
-  # every push to the `deploy` branch. The `:deploy` tag always points at
+  # every push to the `main` branch. The `:main` tag always points at
   # the latest commit on that branch.
   repository: ghcr.io/evergreen-ci/evergreen-mcp-server
-  tag: deploy
+  tag: main
 
 # CLI args for the main container — serve streamable-http on :8080.
 args:

--- a/environments/common.yml
+++ b/environments/common.yml
@@ -1,0 +1,76 @@
+# Shared values for evergreen-mcp-server in the devprod-evergreen namespace.
+# Layered with environments/staging.yml or environments/production.yml.
+# Chart: mongodb/web-app (https://10gen.github.io/helm-charts)
+
+image:
+  repository: 795250896452.dkr.ecr.us-east-1.amazonaws.com/devprod-evergreen/evergreen-mcp-server
+  # tag is injected per-deploy via `--set image.tag=<sha>` in .drone.yml
+
+# Main container: streamable-http on :8080 (path /mcp)
+args:
+  - "--transport"
+  - "streamable-http"
+  - "--host"
+  - "0.0.0.0"
+  - "--port"
+  - "8080"
+
+# Sidecar: SSE transport on :8081 (path /sse)
+sidecars:
+  sse:
+    image: 795250896452.dkr.ecr.us-east-1.amazonaws.com/devprod-evergreen/evergreen-mcp-server
+    args:
+      - "--transport"
+      - "sse"
+      - "--host"
+      - "0.0.0.0"
+      - "--port"
+      - "8081"
+    ports:
+      - containerPort: 8081
+        name: sse
+    env:
+      - name: EVERGREEN_USER
+        valueFrom:
+          secretKeyRef:
+            name: evergreen-mcp-server-secrets
+            key: EVERGREEN_USER
+      - name: EVERGREEN_API_KEY
+        valueFrom:
+          secretKeyRef:
+            name: evergreen-mcp-server-secrets
+            key: EVERGREEN_API_KEY
+      - name: SENTRY_ENABLED
+        value: "true"
+
+services:
+  - name: streamable-http
+    port: 8080
+    targetPort: 8080
+    ingress: true
+    probes: true
+  - name: sse
+    port: 8081
+    targetPort: 8081
+    ingress: true
+    probes: true
+
+# Secret `evergreen-mcp-server-secrets` is provisioned out-of-band per namespace:
+#   helm ksec set evergreen-mcp-server-secrets \
+#     EVERGREEN_USER=<user> EVERGREEN_API_KEY=<key> -n devprod-evergreen
+envSecrets:
+  EVERGREEN_USER: evergreen-mcp-server-secrets
+  EVERGREEN_API_KEY: evergreen-mcp-server-secrets
+
+env:
+  SENTRY_ENABLED: "true"
+
+mesh:
+  enabled: true
+
+ownership:
+  # TODO: swap to a team-alias email once the service has a clear owner
+  driEmail: shreeven.kommireddy@mongodb.com
+
+security:
+  dataClassification: internal

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -1,0 +1,18 @@
+replicaCount: 2
+
+ingress:
+  hosts:
+    - host: evergreen-mcp-server.devprod-evergreen.prod.corp.mongodb.com
+      paths:
+        - path: /mcp
+          serviceName: streamable-http
+        - path: /sse
+          serviceName: sse
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 1
+    memory: 1Gi

--- a/environments/production.yml
+++ b/environments/production.yml
@@ -1,13 +1,9 @@
 replicaCount: 2
 
 ingress:
+  enabled: true
   hosts:
-    - host: evergreen-mcp-server.devprod-evergreen.prod.corp.mongodb.com
-      paths:
-        - path: /mcp
-          serviceName: streamable-http
-        - path: /sse
-          serviceName: sse
+    - evergreen-mcp-server.devprod-evergreen.prod.corp.mongodb.com
 
 resources:
   requests:

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -1,0 +1,18 @@
+replicaCount: 1
+
+ingress:
+  hosts:
+    - host: evergreen-mcp-server.devprod-evergreen.staging.corp.mongodb.com
+      paths:
+        - path: /mcp
+          serviceName: streamable-http
+        - path: /sse
+          serviceName: sse
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi

--- a/environments/staging.yml
+++ b/environments/staging.yml
@@ -1,13 +1,9 @@
 replicaCount: 1
 
 ingress:
+  enabled: true
   hosts:
-    - host: evergreen-mcp-server.devprod-evergreen.staging.corp.mongodb.com
-      paths:
-        - path: /mcp
-          serviceName: streamable-http
-        - path: /sse
-          serviceName: sse
+    - evergreen-mcp-server.devprod-evergreen.staging.corp.mongodb.com
 
 resources:
   requests:

--- a/src/evergreen_mcp/server.py
+++ b/src/evergreen_mcp/server.py
@@ -514,6 +514,24 @@ def main() -> None:
         type=str,
         help="Workspace directory for auto-detecting project ID (optional)",
     )
+    parser.add_argument(
+        "--transport",
+        choices=["stdio", "sse", "streamable-http", "http"],
+        default=os.getenv("EVERGREEN_MCP_TRANSPORT", "stdio"),
+        help="Transport protocol (default: stdio). Env: EVERGREEN_MCP_TRANSPORT.",
+    )
+    parser.add_argument(
+        "--host",
+        type=str,
+        default=os.getenv("EVERGREEN_MCP_HOST", "127.0.0.1"),
+        help="Host to bind for HTTP transports. Env: EVERGREEN_MCP_HOST.",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=int(os.getenv("EVERGREEN_MCP_PORT", "8000")),
+        help="Port to bind for HTTP transports. Env: EVERGREEN_MCP_PORT.",
+    )
 
     args = parser.parse_args()
 
@@ -527,8 +545,11 @@ def main() -> None:
         os.environ["EVERGREEN_PROJECT"] = args.project_id
         logger.info("Using explicit project ID: %s", args.project_id)
 
-    logger.info("Starting FastMCP server...")
-    mcp.run()
+    logger.info("Starting FastMCP server (transport=%s)...", args.transport)
+    if args.transport == "stdio":
+        mcp.run()
+    else:
+        mcp.run(transport=args.transport, host=args.host, port=args.port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Brings the full Kanopy deployment scaffolding for `evergreen-mcp-server` onto `main` and wires CI/CD to **deploy on push to `main`**.

The service runs in the `devprod-evergreen` namespace using the `mongodb/web-app` Helm chart (v4.34.3), serving `streamable-http` on port 8080 with API-key auth. Image is built by GitHub Actions and published to `ghcr.io/evergreen-ci/evergreen-mcp-server`; Drone only deploys.

## Deploy model

| | Trigger |
|---|---|
| **Production** | **Automatic** on push to `main` |
| **Staging** | **Manual**: `drone build promote evergreen-ci/evergreen-mcp-server <build-number> staging` |

⚠️ With this scheme, every push to `main` ships straight to prod — there is no staging gate in between. Staging is opt-in via promote.

## What's included

- `.drone.yml` — `publish-to-production` (push to main) + `publish-to-staging` (manual promote) pipelines.
- `.github/workflows/docker-build.yml` — build/push image on push to `main`; tagged `:main`.
- `environments/{common,staging,production}.yml` — Helm values per environment.
- `src/evergreen_mcp/server.py` — real `--transport`/`--host`/`--port` CLI args (env-var defaults) so the server can serve HTTP, not just stdio.

## Out-of-band prerequisites (already done on the cluster)

- Drone repo secrets: `prod_kubernetes_token`, `staging_kubernetes_token`.
- K8s secret `evergreen-mcp-server-secrets` (`EVERGREEN_USER`, `EVERGREEN_API_KEY`) provisioned via `helm ksec` in both clusters.
